### PR TITLE
Add wikimedia's migration to PHP7

### DIFF
--- a/php-timeline.json
+++ b/php-timeline.json
@@ -64,6 +64,14 @@
         "comment": ""
     },
     {
+        "priority": 2,
+        "date": "2020-01-05T00:00:00+00:00",
+        "title": "Wikipedia moves back to PHP7",
+        "href": "https://phabricator.wikimedia.org/T229792",
+        "description": "",
+        "comment": ""
+    },
+        {
         "priority": 3,
         "date": "2019-12-15T00:00:00+00:00",
         "title": "CakePHP 4.0",


### PR DESCRIPTION
Adding this on the basis that "If HHVM migration is worth noting, migrating back to PHP7 is also
probably notable".

I couldn't find a Mailing list announcement that the stuff is complete, so I used the issue @ WMF issue tracker for references. Feel free to modify the href and date stuff.